### PR TITLE
Prevent footer text from overflowing

### DIFF
--- a/gnudoc-webapp/style.css
+++ b/gnudoc-webapp/style.css
@@ -54,7 +54,7 @@ ul#contents li {
 footer {
     background-color: #336666;
     color: #fef3f3;
-    height: 10em;
+    min-height: 10em;
     border-top: double #224444; solid;
     margin: 0;
     padding-top: 1em;


### PR DESCRIPTION
Prevent footer text from overflowing on devices with small screens.

Before my fix (I have selected the text to make it easier to see):
![screenshot](https://cloud.githubusercontent.com/assets/4295266/3787898/66d9c4a2-1a3f-11e4-9b7b-5a3723bde7c5.png)

After my fix:
![screenshot from 2014-08-02 13 24 52](https://cloud.githubusercontent.com/assets/4295266/3787901/0b4f4480-1a40-11e4-8d91-08c0bbfe1957.png)
