### PR TITLE
use official jquery npm package

### DIFF
--- a/gnudoc-webapp/scripts/app.js
+++ b/gnudoc-webapp/scripts/app.js
@@ -1,5 +1,5 @@
 var util = require("util");
-var $ = require("jquery-browserify");
+var $ = require("jquery");
 var clickHistory = [];
 
 var commands = {
@@ -50,7 +50,7 @@ function docGet (infoTarget) {
     error: function () {
       alert(util.format("something went wrong getting %s", resource));
     },
-    success: function (data) { 
+    success: function (data) {
       var newData = data.replace(
         "<body>", "<body><div class=\"doc\" id=\"body\">"
       ).replace(
@@ -95,13 +95,13 @@ function keyDispatch (evt) {
 }
 
 $("#index").load(
-  "/manual/elisp/index.html #content", 
+  "/manual/elisp/index.html #content",
   function () {
     console.log("content is loaded!");
     var docTables = $("#index table");
     // If we use the tr we could possibly get the 2nd TD, a long description
     var hrefs = $("tr", docTables.get(0)).map(
-      function (i, e) { 
+      function (i, e) {
         var a = $("a", e);
         return { "href": a.attr("href"), "text": a.text() };
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "http://nic.ferrier.me.uk"
   },
   "dependencies": {
-    "jquery-browserify": "1.8.1",
+    "jquery": "2.1.1",
     "browserify": ">=4.2.0"
   }
 }


### PR DESCRIPTION
The package jquery-browserify is currently being used.

The official [jquery package ](https://www.npmjs.org/package/jquery) supports browserify and is up to date.
